### PR TITLE
Add AsmVar to cloud setup script

### DIFF
--- a/cloud/setup-cloud.sh
+++ b/cloud/setup-cloud.sh
@@ -106,6 +106,24 @@ git clone https://github.com/bioinformatics-centre/AsmVar
 cd AsmVar/src/AsmvarDetect
 make
 
+cd /ebs1
+wget https://github.com/Martinsos/edlib/archive/v1.2.4.tar.gz
+tar -xzvf v1.2.4.tar.gz
+rm v1.2.4.tar.gz
+cd edlib-1.2.4/build
+cmake -D CMAKE_BUILD_TYPE=Release ..
+make
+export PATH="/ebs1/edlib-1.2.4/build/bin:$PATH"
+
+cd /ebs1
+git clone git://github.com/nhansen/SVanalyzer.git
+cd SVanalyzer
+cpan Module::Build
+perl Build.PL
+./Build
+./Build test
+sudo ./Build install
+
 export PATH="/ebs1/vcflib/bin:$PATH"
 export PATH="/ebs1/seqwish/bin:$PATH"
 export PATH="/ebs1/minimap2:$PATH"

--- a/cloud/setup-cloud.sh
+++ b/cloud/setup-cloud.sh
@@ -21,6 +21,7 @@ sudo apt install -y tabix
 sudo apt install -y libssl-dev
 sudo apt install -y docker.io
 sudo usermod -aG docker $USER
+sudo apt install -y last-align
 printf "\n\nNeed to log out then in for Docker to work!!\n\n"
 
 mkdir /ebs1
@@ -100,12 +101,17 @@ export PATH="/ebs1/cactus/submodules/hdf5/bin:$PATH"
 export h5prefix="-prefix=/ebs1/cactus/submodules/hdf5"
 make
 
+cd /ebs1
+git clone https://github.com/bioinformatics-centre/AsmVar
+cd AsmVar/src/AsmvarDetect
+make
+
 export PATH="/ebs1/vcflib/bin:$PATH"
 export PATH="/ebs1/seqwish/bin:$PATH"
 export PATH="/ebs1/minimap2:$PATH"
 export PATH="/ebs1/bcftools:$PATH"
 export PATH="/ebs1/hal2vg:$PATH"
 export PATH="/ebs1/repeatMaskerPipeline:$PATH"
-
+export PATH="/ebs1/AsmVar/src/AsmvarDetect:$PATH"
 
 


### PR DESCRIPTION
Hi Glenn,
this should be all it takes to install AsmVar. On their github page they list scipy, numpy, scikit-learn and matplotlib as other dependencies but I think I didn't need that for my yeast experiments.

I encountered only one problem during the installation where g++ complained:
```
ubuntu:/ebs1/AsmVar/src/AsmvarDetect$ g++ -lz -o ASV_VariantDetector main.o utility.o Variant.o VarUnit.o gzstream.o AGEaligner.o vcf.o Region.o
gzstream.o: In function `gzstreambuf::open(char const*, int)':
gzstream.cpp:(.text+0x10b): undefined reference to `gzopen'
gzstream.o: In function `gzstreambuf::close()':
gzstream.cpp:(.text+0x1a3): undefined reference to `gzclose'
gzstream.o: In function `gzstreambuf::underflow()':
gzstream.cpp:(.text+0x2e2): undefined reference to `gzread'
gzstream.o: In function `gzstreambuf::flush_buffer()':
gzstream.cpp:(.text+0x3a6): undefined reference to `gzwrite'
collect2: error: ld returned 1 exit status
```

Moving the `-lz` option to the end did the trick for me:
`g++ -o ASV_VariantDetector main.o utility.o Variant.o VarUnit.o gzstream.o AGEaligner.o vcf.o Region.o -lz`